### PR TITLE
deps: Updated to Smoketest 2.2.0

### DIFF
--- a/tests/.duget
+++ b/tests/.duget
@@ -1,6 +1,6 @@
 {
   references: [
     "&..\\.duspec",
-    "deltics.smoketest:2.1.0"
+    "deltics.smoketest:2.2.0"
   ]
 }


### PR DESCRIPTION
Eliminates Smoketest warnings in Delphi 7 build